### PR TITLE
Use accessor instead of low level header value in t/catalyst-action-serialize-accept.t  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+sudo: false
 language: perl
 perl:
+   - "5.20"
    - "5.18"
    - "5.16"
    - "5.14"
@@ -9,12 +11,7 @@ perl:
 
 install:
    - export RELEASE_TESTING=1 AUTOMATED_TESTING=1 AUTHOR_TESTING=1 HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
-   - cpanm --quiet --notest Devel::Cover::Report::Coveralls
    - cpanm --quiet --notest --installdeps --with-suggests .
 
 script:
-   - PERL5OPT=-MDevel::Cover=-coverage,statement,branch,condition,path,subroutine prove -lrsv t
-   - cover
-
-after_success:
-  - cover -report coveralls
+   - prove -lrsv t

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'Catalyst::Runtime' => '5.80030' ;
 requires 'Class::Inspector' => '1.13' ;
-requires 'LWP::UserAgent' => '2.033' ;
+requires 'LWP::UserAgent' => '5.00' ;
 requires 'MRO::Compat' => '0.10' ;
 requires 'Module::Pluggable::Object' => undef ;
 requires 'Moose' => '1.03';

--- a/lib/Catalyst/Action/REST.pm
+++ b/lib/Catalyst/Action/REST.pm
@@ -251,9 +251,11 @@ Colin Newell <colin@opusvl.com>
 
 Wallace Reis E<lt>wreis@cpan.orgE<gt>
 
+André Walker (andrewalker) <andre@cpan.org>
+
 =head1 COPYRIGHT
 
-Copyright (c) 2006-2012 the above named AUTHOR and CONTRIBUTORS
+Copyright (c) 2006-2015 the above named AUTHOR and CONTRIBUTORS
 
 =head1 LICENSE
 

--- a/t/catalyst-action-serialize-accept.t
+++ b/t/catalyst-action-serialize-accept.t
@@ -31,7 +31,7 @@ my $output_YAML = Catalyst::Action::Serialize::YAML->serialize({lou => 'is my ca
              );
         ok( $res->is_success, 'GET the serialized request succeeded' );
         is( $res->content, $output_YAML, "Request returned proper data");
-        is( $res->header('Content-type'), 'text/x-yaml', '... with expected content-type')
+        is( $res->content_type, 'text/x-yaml', '... with expected content-type')
 
     };
 }
@@ -47,7 +47,7 @@ SKIP: {
     ok( $res->is_success, 'GET the serialized request succeeded' );
     my $ret = $json->decode($res->content);
     is( $ret->{lou}, 'is my cat', "Request returned proper data");
-    is( $res->header('Content-type'), 'application/json', 'Accept header used if content-type mapping not found')
+    is( $res->content_type, 'application/json', 'Accept header used if content-type mapping not found')
 };
 
 # Make sure we don't get a bogus content-type when using the default
@@ -59,7 +59,7 @@ SKIP: {
     my $res = request($req);
     ok( $res->is_success, 'GET the serialized request succeeded' );
     is( $res->content, $output_YAML, "Request returned proper data");
-    is( $res->header('Content-type'), 'text/x-yaml', '... with expected content-type')
+    is( $res->content_type, 'text/x-yaml', '... with expected content-type')
 }
 
 # Make sure that when using content_type_stash_key, an invalid value in the stash gets ignored
@@ -70,7 +70,7 @@ SKIP: {
     my $res = request($req);
     ok( $res->is_success, 'GET the serialized request succeeded' );
     is( $res->content, $output_YAML, "Request returned proper data");
-    is( $res->header('Content-type'), 'text/x-yaml', '... with expected content-type')
+    is( $res->content_type, 'text/x-yaml', '... with expected content-type')
 }
 
 # Make sure that the default content type you specify really gets used.


### PR DESCRIPTION
The test was failing in recent Catalyst versions because it was fetching the header value using `` $res->header('Content-Type')`` instead of ``$res->content_type``. The former would get the entire HTTP header, which recent versions would append the charset, thus changing the expected value from ``text/x-yaml`` to ``text/x-yaml; charset=UTF-8``.

The ``->content_type`` accessor parses the header, and returns (in the example): ``('text/x-yaml', 'charset=UTF-8')`` in list context, and simply ``text/x-yaml`` in scalar context. Using this, the test doesn't have to worry about low level details such as the charset defined, which is out of the scope of the test.