### PR TITLE
Fix docs citing incorrect method, "serialize_bad_request"

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
 
+ - Fix docs citing incorrect method name: 'serialize_bad_request' (remove leading underscore)
+
 1.19      2015-02-06 09:40:02-06:00 America/Chicago
 
  - Make LWP a test dep instead of a hard dep (Fixes GH#3, thanks Alexander

--- a/lib/Catalyst/Action/Deserialize.pm
+++ b/lib/Catalyst/Action/Deserialize.pm
@@ -121,7 +121,7 @@ L<Catalyst::Request::REST>.
 
 For building custom error responses when de-serialization fails, you can create
 an ActionRole (and use L<Catalyst::Controller::ActionRole> to apply it to the
-C<begin> action) which overrides C<unsupported_media_type> and/or C<_serialize_bad_request>
+C<begin> action) which overrides C<unsupported_media_type> and/or C<serialize_bad_request>
 methods.
 
 =head1 SEE ALSO

--- a/lib/Catalyst/Action/Serialize.pm
+++ b/lib/Catalyst/Action/Serialize.pm
@@ -152,7 +152,7 @@ with the rest of Catalyst.
 
 For building custom error responses when serialization fails, you can create
 an ActionRole (and use L<Catalyst::Controller::ActionRole> to apply it to the
-C<end> action) which overrides C<unsupported_media_type> and/or C<_serialize_bad_request>
+C<end> action) which overrides C<unsupported_media_type> and/or C<serialize_bad_request>
 methods.
 
 =head1 SEE ALSO


### PR DESCRIPTION
Fix docs to correct error-handling method name: 'serialize_bad_request'
(remove leading underscore)