### PR TITLE
making SerializeBase respect Vary: header if it has already been set

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
 
+1.20      2015-10-29 15:00:00 EST
+ - Make Catalyst::Action::SerializeBase respect Vary headers if previously
+   set by your controller
+
 1.19      2015-02-06 09:40:02-06:00 America/Chicago
 
  - Make LWP a test dep instead of a hard dep (Fixes GH#3, thanks Alexander

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name             = Catalyst-Action-REST
 author           = Tomas Doran <bobtfish@cpan.org>
 license          = Perl_5
 copyright_holder = Tomas Doran
-version          = 1.19
+version          = 1.20
 
 [NextRelease]
 [@Git]

--- a/lib/Catalyst/Action/SerializeBase.pm
+++ b/lib/Catalyst/Action/SerializeBase.pm
@@ -118,10 +118,12 @@ sub _load_content_plugins {
     }
 
     if ($search_path eq "Catalyst::Action::Serialize") {
-        if ($content_type) {
-            $c->response->header( 'Vary' => 'Content-Type' );
-        } elsif ($c->request->accept_only) {
-            $c->response->header( 'Vary' => 'Accept' );
+        unless( $c->response->header( 'Vary' ) ) {
+            if ($content_type) {
+                $c->response->header( 'Vary' => 'Content-Type' );
+            } elsif ($c->request->accept_only) {
+                $c->response->header( 'Vary' => 'Accept' );
+            }
         }
         $c->response->content_type($content_type);
     }


### PR DESCRIPTION
When specifying a Vary header in my controller Catalyst::Action::SerializeBase clobbers it with either Vary: Accepts or Vary: Content-Type.  This patch respects any previously set Vary header prior to setting one of its own.