### PR TITLE
New option json_options_encode to set JSON options for output

### DIFF
--- a/lib/Catalyst/Action/Serialize/JSON.pm
+++ b/lib/Catalyst/Action/Serialize/JSON.pm
@@ -20,6 +20,12 @@ sub execute {
     my $self = shift;
     my ( $controller, $c ) = @_;
 
+    if (my $options = $controller->{json_options_encode}) {
+        foreach my $opt (keys %$options) {
+            $self->encoder->$opt( $options->{$opt} );
+        }
+    }
+
     my $stash_key = (
             $controller->{'serialize'} ?
                 $controller->{'serialize'}->{'stash_key'} :

--- a/lib/Catalyst/Controller/REST.pm
+++ b/lib/Catalyst/Controller/REST.pm
@@ -147,10 +147,21 @@ L<JSON::XS> installed.  The C<text/x-json> content type is supported but is
 deprecated and you will receive warnings in your log.
 
 You can also add a hash in your controller config to pass options to the json object.
+There are two options. C<json_options> are used when decoding incoming JSON, and C<json_options_encode> 
+is used when encoding JSON for output.
+
 For instance, to relax permissions when deserializing input, add:
+
   __PACKAGE__->config(
     json_options => { relaxed => 1 }
   )
+
+To indent the JSON output so it becomes more human readable, add:
+
+  __PACKAGE__->config(
+    json_options_encode => { indent => 1 }
+  )
+
 
 =item * C<text/javascript> => C<JSONP>
 


### PR DESCRIPTION
It is good to be able to set flags like pretty and indent when making json. This is an updated version of the code first submitted in pull request #6 , to address possible lack of interchangeability of the json options for input and output.
