### PR TITLE
Make 'Accept' header have higher priority than 'Content-Type'

### DIFF
--- a/lib/Catalyst/TraitFor/Request/REST.pm
+++ b/lib/Catalyst/TraitFor/Request/REST.pm
@@ -103,10 +103,9 @@ sub _build_accepted_content_types {
 
     my %types;
 
-    # First, we use the content type in the HTTP Request.  It wins all.
-    # But only examine it if we're not in compliance mode or if we're
-    # in deserializing mode
-    $types{ $self->content_type } = 3
+    # Check for a content type in the HTTP Request, it has lower priority than
+    # the Accept header for serialization.
+    $types{ $self->content_type } = 0
         if $self->content_type && $self->content_type_allowed();
 
     # Seems backwards, but users are used to adding &content-type= to the uri to
@@ -118,7 +117,9 @@ sub _build_accepted_content_types {
     }
 
     # Third, we parse the Accept header, and see if the client
-    # takes a format we understand.
+    # takes a format we understand. This takes priority over Content-Type if
+    # provided.
+    # 
     # But only examine it if we're not in compliance mode or if we're
     # in serializing mode
     #

--- a/t/catalyst-traitfor-request-rest.t
+++ b/t/catalyst-traitfor-request-rest.t
@@ -46,10 +46,10 @@ for my $class ( $anon_class, 'Catalyst::Request::REST' ) {
         $request->method('GET');
         $request->content_type('text/foobar');
 
-        is_deeply( $request->accepted_content_types, [ 'text/foobar', 'text/fudge' ],
+        is_deeply( $request->accepted_content_types, [ 'text/fudge', 'text/foobar' ],
                    'content-type set in request headers and type in parameters is found' );
-        is( $request->preferred_content_type, 'text/foobar',
-            'preferred content type is text/foobar' );
+        is( $request->preferred_content_type, 'text/fudge',
+            'preferred content type is text/fudge' );
         ok( ! $request->accept_only, 'accept_only is false' );
         ok( $request->accepts('text/foobar'), 'accepts text/foobar' );
         ok( $request->accepts('text/fudge'), 'accepts text/fudge' );
@@ -109,14 +109,15 @@ for my $class ( $anon_class, 'Catalyst::Request::REST' ) {
         );
 
         is_deeply( $request->accepted_content_types,
-                   [ qw( application/json
+                   [ qw( 
                          text/xml application/xml application/xhtml+xml
                          image/png
                          text/html
                          text/plain
                          */*
+                         application/json
                        ) ],
-                   'accept header is parsed properly, and content-type header has precedence over accept' );
+                   'accept header is parsed properly, and accept header has precedence over content-type' );
         ok( ! $request->accept_only, 'accept_only is false' );
     }
 
@@ -134,14 +135,14 @@ for my $class ( $anon_class, 'Catalyst::Request::REST' ) {
         );
 
         is_deeply( $request->accepted_content_types,
-                   [ qw( application/json
-                         text/xml application/xml application/xhtml+xml
+                   [ qw( text/xml application/xml application/xhtml+xml
                          image/png
                          text/html
                          text/plain
                          */*
+                         application/json
                        ) ],
-                   'accept header is parsed properly, and content-type header has precedence over accept' );
+                   'accept header is parsed properly, and accept header has precedence over content-type' );
         ok( ! $request->accept_only, 'accept_only is false' );
     }
 
@@ -157,8 +158,8 @@ for my $class ( $anon_class, 'Catalyst::Request::REST' ) {
         );
 
         is_deeply( $request->accepted_content_types,
-                   [ qw( text/x-json
-                         text/plain
+                   [ qw( text/plain
+                         text/x-json
                        ) ],
                    'each type appears only once' );
     }
@@ -175,8 +176,8 @@ for my $class ( $anon_class, 'Catalyst::Request::REST' ) {
         );
 
         is_deeply( $request->accepted_content_types,
-                   [ qw( application/json
-                         text/plain
+                   [ qw( text/plain
+                         application/json
                        ) ],
                    'each type appears only once' );
     }


### PR DESCRIPTION
The 'Accept' header should have higher priority during serialization than the 'Content-Type' header.

This is a fix for https://rt.cpan.org/Public/Bug/Display.html?id=46974