### PR TITLE
fix syntax of Catalyst::Runtime version checks

### DIFF
--- a/t/lib/Test/Catalyst/Action/REST.pm
+++ b/t/lib/Test/Catalyst/Action/REST.pm
@@ -3,7 +3,7 @@ package Test::Catalyst::Action::REST;
 use Moose;
 use namespace::autoclean;
 
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 
 use Catalyst;
 use FindBin;

--- a/t/lib/Test/Serialize.pm
+++ b/t/lib/Test/Serialize.pm
@@ -7,7 +7,7 @@ use lib ("$FindBin::Bin/../lib");
 use Moose;
 use namespace::autoclean;
 
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 
 use Catalyst;
 use Test::Catalyst::Log;


### PR DESCRIPTION
A version requirement on a use statement must be a number or a vstring. It cannot be a string. A string will be treated as an argument to ->import. Catalyst::Runtime doesn't have an import method, so the argument would just be ignored. Future versions of perl are intending to make passing arguments to an undefined import method an error.